### PR TITLE
handle non-string metadata values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,59 +14,24 @@ jobs:
 
   build-and-test:
     macos:
-      xcode: 12.0.0 # Specify the Xcode version to use
+      xcode: 13.0.0 # Specify the Xcode version to use
 
     steps:
       - checkout
 
-      # restore pods related caches
-      - restore_cache:
-          keys:
-            - 1-gems-{{ checksum "Gemfile.lock" }}
-
-      # make sure we're on the right version of cocoapods
+      # pre-start the simulator to prevent timeouts
       - run:
-          name: Verify Cocoapods Version
-          command: bundle check || bundle install --path vendor/bundle
-
-      # save cocoapods version gem data
-      - save_cache:
-          key: 1-gems-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
-
-      # restore pods related caches
-      - restore_cache:
-          keys:
-            - cocoapods-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "Podfile.lock" }}
-            - cocoapods-cache-v5-{{ arch }}-{{ .Branch }}
-            - cocoapods-cache-v5
+          name: Pre-start Simulator
+          command: xcrun instruments -w "iPhone 8 (13.1) [" || true
 
       # install CocoaPods - using default CocoaPods version, not the bundle
       - run:
           name: Repo Update & Install CocoaPods
           command: make ci-pod-install
 
-      # save pods related files
-      - save_cache:
-          name: Saving CocoaPods Cache
-          key: cocoapods-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "Podfile.lock" }}
-          paths:
-            - ./Pods
-            - ~/.cocoapods
-
-      - run:
-          name: Install SwiftLint
-          command: make install-swiftlint
-
       - run:
           name: Lint Source Code
           command: make lint
-
-      # pre-start the simulator to prevent timeouts
-      - run:
-          name: Pre-start Simulator
-          command: xcrun instruments -w "iPhone 8 (13.1) [" || true
 
       - run:
           name: Run Tests
@@ -84,7 +49,7 @@ jobs:
             for i in 1 256 512
             do
               shasum -a $i -c --ignore-missing <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") ||
-              shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM" | head -n 1)
+              shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM" | grep -w "codecov")
             done
             bash ./codecov -v -X s3 -c -D "./build/out" -J "AEPPlaces"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,8 @@ jobs:
 
       # install CocoaPods - using default CocoaPods version, not the bundle
       - run:
-          name: Repo Update & Install CocoaPods
-          command: make ci-pod-install
+          name: CocoaPods install
+          command: pod install
 
       - run:
           name: Lint Source Code

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ fastlane/test_output
 iOSInjectionProject/
 
 .DS_Store
+
+.vscode

--- a/AEPPlaces.podspec
+++ b/AEPPlaces.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "AEPPlaces"
-  s.version      = "3.0.1"
+  s.version      = "3.1.0"
   s.summary      = "Places extension for Adobe Experience Cloud SDK. Written and maintained by Adobe."
   s.description  = <<-DESC
                    The Places extension is used in conjunction with Adobe Experience Platform to deliver location functionality.

--- a/AEPPlaces.podspec
+++ b/AEPPlaces.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "AEPPlaces"
-  s.version      = "3.1.0"
+  s.version      = "3.0.2"
   s.summary      = "Places extension for Adobe Experience Cloud SDK. Written and maintained by Adobe."
   s.description  = <<-DESC
                    The Places extension is used in conjunction with Adobe Experience Platform to deliver location functionality.

--- a/AEPPlaces.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/AEPPlaces.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/AEPPlaces/Sources/PlacesConstants.swift
+++ b/AEPPlaces/Sources/PlacesConstants.swift
@@ -14,7 +14,7 @@ import Foundation
 
 enum PlacesConstants {
     static let EXTENSION_NAME = "com.adobe.module.places"
-    static let EXTENSION_VERSION = "3.1.0"
+    static let EXTENSION_VERSION = "3.0.2"
     static let FRIENDLY_NAME = EXTENSION_NAME
     static let LOG_TAG = "Places"
 

--- a/AEPPlaces/Sources/PlacesConstants.swift
+++ b/AEPPlaces/Sources/PlacesConstants.swift
@@ -14,7 +14,7 @@ import Foundation
 
 enum PlacesConstants {
     static let EXTENSION_NAME = "com.adobe.module.places"
-    static let EXTENSION_VERSION = "3.0.1"
+    static let EXTENSION_VERSION = "3.1.0"
     static let FRIENDLY_NAME = EXTENSION_NAME
     static let LOG_TAG = "Places"
 

--- a/AEPPlaces/Sources/PointOfInterest.swift
+++ b/AEPPlaces/Sources/PointOfInterest.swift
@@ -21,7 +21,7 @@ public class PointOfInterest: NSObject {
     @objc public var latitude: Double
     @objc public var longitude: Double
     @objc public var radius: Int
-    @objc public var metaData: [String: Any]
+    @objc public var metaData: [String: String]
     @objc public var userIsWithin: Bool
 
     @objc public private(set) var libraryId: String
@@ -49,7 +49,8 @@ public class PointOfInterest: NSObject {
                 weight = json[PlacesConstants.EventDataKey.Places.WEIGHT] as? Int ?? 0
                 libraryId = json[PlacesConstants.EventDataKey.Places.LIBRARY_ID] as? String ?? ""
                 userIsWithin = json[PlacesConstants.EventDataKey.Places.USER_IS_WITHIN] as? Bool ?? false
-                metaData = json[PlacesConstants.EventDataKey.Places.REGION_META_DATA] as? [String: Any] ?? [:]
+                let metaDataAny = json[PlacesConstants.EventDataKey.Places.REGION_META_DATA] as? [String: Any] ?? [:]
+                metaData = metaDataAny.mapValues { String(describing: $0) }
             } else {
                 Log.warning(label: PlacesConstants.LOG_TAG, "An error occurred while trying to read a PointOfInterest json string.")
                 throw PlacesDataObjectInvalidInitialization(message: "Invalid JSON string")
@@ -86,7 +87,8 @@ public class PointOfInterest: NSObject {
         self.libraryId = poiInfo[PlacesConstants.QueryService.Index.LIBRARY_ID] as? String ?? ""
         self.weight = poiInfo[PlacesConstants.QueryService.Index.WEIGHT] as? Int ?? 0
         self.userIsWithin = userIsWithin!
-        self.metaData = jsonObject[PlacesConstants.QueryService.Json.META_DATA] as? [String: Any] ?? [:]
+        let metaDataAny = jsonObject[PlacesConstants.QueryService.Json.META_DATA] as? [String: Any] ?? [:]
+        self.metaData = metaDataAny.mapValues { String(describing: $0) }
     }
 
     /// Converts and returns the contents of this `PointOfInterest` as a JSON string.

--- a/AEPPlaces/Sources/PointOfInterest.swift
+++ b/AEPPlaces/Sources/PointOfInterest.swift
@@ -21,7 +21,7 @@ public class PointOfInterest: NSObject {
     @objc public var latitude: Double
     @objc public var longitude: Double
     @objc public var radius: Int
-    @objc public var metaData: [String: String]
+    @objc public var metaData: [String: Any]
     @objc public var userIsWithin: Bool
 
     @objc public private(set) var libraryId: String
@@ -49,7 +49,7 @@ public class PointOfInterest: NSObject {
                 weight = json[PlacesConstants.EventDataKey.Places.WEIGHT] as? Int ?? 0
                 libraryId = json[PlacesConstants.EventDataKey.Places.LIBRARY_ID] as? String ?? ""
                 userIsWithin = json[PlacesConstants.EventDataKey.Places.USER_IS_WITHIN] as? Bool ?? false
-                metaData = json[PlacesConstants.EventDataKey.Places.REGION_META_DATA] as? [String: String] ?? [:]
+                metaData = json[PlacesConstants.EventDataKey.Places.REGION_META_DATA] as? [String: Any] ?? [:]
             } else {
                 Log.warning(label: PlacesConstants.LOG_TAG, "An error occurred while trying to read a PointOfInterest json string.")
                 throw PlacesDataObjectInvalidInitialization(message: "Invalid JSON string")
@@ -86,7 +86,7 @@ public class PointOfInterest: NSObject {
         self.libraryId = poiInfo[PlacesConstants.QueryService.Index.LIBRARY_ID] as? String ?? ""
         self.weight = poiInfo[PlacesConstants.QueryService.Index.WEIGHT] as? Int ?? 0
         self.userIsWithin = userIsWithin!
-        self.metaData = jsonObject[PlacesConstants.QueryService.Json.META_DATA] as? [String: String] ?? [:]
+        self.metaData = jsonObject[PlacesConstants.QueryService.Json.META_DATA] as? [String: Any] ?? [:]
     }
 
     /// Converts and returns the contents of this `PointOfInterest` as a JSON string.

--- a/AEPPlaces/Tests/PlacesQueryServiceTests.swift
+++ b/AEPPlaces/Tests/PlacesQueryServiceTests.swift
@@ -214,7 +214,7 @@ class PlacesQueryServiceTests: XCTestCase {
             XCTAssertTrue(returnedPoi.userIsWithin)
             XCTAssertEqual("mylib", returnedPoi.libraryId)
             XCTAssertEqual(25, returnedPoi.weight)
-            XCTAssertEqual("value1", returnedPoi.metaData["key1"])
+            XCTAssertEqual("value1", returnedPoi.metaData["key1"] as? String)
             
             expectation.fulfill()
         }
@@ -251,7 +251,7 @@ class PlacesQueryServiceTests: XCTestCase {
             XCTAssertTrue(returnedPoi.userIsWithin)
             XCTAssertEqual("mylib", returnedPoi.libraryId)
             XCTAssertEqual(25, returnedPoi.weight)
-            XCTAssertEqual("value1", returnedPoi.metaData["key1"])
+            XCTAssertEqual("value1", returnedPoi.metaData["key1"] as? String)
             
             expectation.fulfill()
         }
@@ -288,7 +288,7 @@ class PlacesQueryServiceTests: XCTestCase {
             XCTAssertFalse(returnedPoi.userIsWithin)
             XCTAssertEqual("mylib", returnedPoi.libraryId)
             XCTAssertEqual(25, returnedPoi.weight)
-            XCTAssertEqual("value1", returnedPoi.metaData["key1"])
+            XCTAssertEqual("value1", returnedPoi.metaData["key1"] as? String)
             
             expectation.fulfill()
         }
@@ -325,7 +325,7 @@ class PlacesQueryServiceTests: XCTestCase {
             XCTAssertFalse(returnedPoi.userIsWithin)
             XCTAssertEqual("mylib", returnedPoi.libraryId)
             XCTAssertEqual(25, returnedPoi.weight)
-            XCTAssertEqual("value1", returnedPoi.metaData["key1"])
+            XCTAssertEqual("value1", returnedPoi.metaData["key1"] as? String)
             
             expectation.fulfill()
         }
@@ -363,7 +363,7 @@ class PlacesQueryServiceTests: XCTestCase {
             XCTAssertTrue(returnedPoi.userIsWithin)
             XCTAssertEqual("mylib", returnedPoi.libraryId)
             XCTAssertEqual(25, returnedPoi.weight)
-            XCTAssertEqual("value1", returnedPoi.metaData["key1"])
+            XCTAssertEqual("value1", returnedPoi.metaData["key1"] as? String)
             
             let nearbyPoi = result.pois![1]
             XCTAssertEqual("2345", nearbyPoi.identifier)
@@ -374,7 +374,7 @@ class PlacesQueryServiceTests: XCTestCase {
             XCTAssertFalse(nearbyPoi.userIsWithin)
             XCTAssertEqual("yourlib", nearbyPoi.libraryId)
             XCTAssertEqual(30, nearbyPoi.weight)
-            XCTAssertEqual("value2", nearbyPoi.metaData["key2"])
+            XCTAssertEqual("value2", nearbyPoi.metaData["key2"] as? String)
             
             expectation.fulfill()
         }
@@ -412,7 +412,7 @@ class PlacesQueryServiceTests: XCTestCase {
             XCTAssertFalse(poi1.userIsWithin)
             XCTAssertEqual("mylib", poi1.libraryId)
             XCTAssertEqual(25, poi1.weight)
-            XCTAssertEqual("value1", poi1.metaData["key1"])
+            XCTAssertEqual("value1", poi1.metaData["key1"] as? String)
             
             let poi2 = result.pois![1]
             XCTAssertEqual("2345", poi2.identifier)
@@ -423,7 +423,7 @@ class PlacesQueryServiceTests: XCTestCase {
             XCTAssertFalse(poi2.userIsWithin)
             XCTAssertEqual("yourlib", poi2.libraryId)
             XCTAssertEqual(30, poi2.weight)
-            XCTAssertEqual("value2", poi2.metaData["key2"])
+            XCTAssertEqual("value2", poi2.metaData["key2"] as? String)
             
             expectation.fulfill()
         }
@@ -461,7 +461,7 @@ class PlacesQueryServiceTests: XCTestCase {
             XCTAssertTrue(poi1.userIsWithin)
             XCTAssertEqual("mylib", poi1.libraryId)
             XCTAssertEqual(25, poi1.weight)
-            XCTAssertEqual("value1", poi1.metaData["key1"])
+            XCTAssertEqual("value1", poi1.metaData["key1"] as? String)
             
             let poi2 = result.pois![1]
             XCTAssertEqual("2345", poi2.identifier)
@@ -472,7 +472,7 @@ class PlacesQueryServiceTests: XCTestCase {
             XCTAssertTrue(poi2.userIsWithin)
             XCTAssertEqual("yourlib", poi2.libraryId)
             XCTAssertEqual(30, poi2.weight)
-            XCTAssertEqual("value2", poi2.metaData["key2"])
+            XCTAssertEqual("value2", poi2.metaData["key2"] as? String)
             
             expectation.fulfill()
         }

--- a/AEPPlaces/Tests/PlacesTests.swift
+++ b/AEPPlaces/Tests/PlacesTests.swift
@@ -127,11 +127,11 @@ class PlacesTests: XCTestCase {
                                         ], .set))
     }
     
-    func getGetNearbyPlacesRequestEvent() -> Event {
+    func getGetNearbyPlacesRequestEvent(_ data: [String: Any]? = nil) -> Event {
         return Event(name: PlacesConstants.EventName.Request.GET_NEARBY_PLACES,
                      type: EventType.places,
                      source: EventSource.requestContent,
-                     data: [
+                     data: data ?? [
                         PlacesConstants.EventDataKey.Places.LATITUDE: 12.34,
                         PlacesConstants.EventDataKey.Places.LONGITUDE: 23.45,
                         PlacesConstants.EventDataKey.Places.COUNT: 7,
@@ -139,11 +139,11 @@ class PlacesTests: XCTestCase {
                      ])
     }
     
-    func getProcessRegionEvent() -> Event {
+    func getProcessRegionEvent(_ data: [String: Any]? = nil) -> Event {
         return Event(name: PlacesConstants.EventName.Request.PROCESS_REGION_EVENT,
                      type: EventType.places,
                      source: EventSource.requestContent,
-                     data: [
+                     data: data ?? [
                         PlacesConstants.EventDataKey.Places.REGION_ID: "1234",
                         PlacesConstants.EventDataKey.Places.REGION_EVENT_TYPE: PlacesRegionEvent.entry.stringValue,
                         PlacesConstants.EventDataKey.Places.REQUEST_TYPE: PlacesConstants.EventDataKey.Places.RequestType.PROCESS_REGION_EVENT
@@ -168,21 +168,21 @@ class PlacesTests: XCTestCase {
                      ])
     }
     
-    func getSetAuthorizationStatusRequestEvent() -> Event {
+    func getSetAuthorizationStatusRequestEvent(_ data: [String: Any]? = nil) -> Event {
         return Event(name: PlacesConstants.EventName.Request.SET_AUTHORIZATION_STATUS,
                      type: EventType.places,
                      source: EventSource.requestContent,
-                     data: [
+                     data: data ?? [
                         PlacesConstants.EventDataKey.Places.REQUEST_TYPE: PlacesConstants.EventDataKey.Places.RequestType.SET_AUTHORIZATION_STATUS,
                         PlacesConstants.EventDataKey.Places.AUTH_STATUS: "always"
                      ])
     }
     
-    func getSetAccuracyAuthorizationRequestEvent() -> Event {
+    func getSetAccuracyAuthorizationRequestEvent(_ data: [String: Any]? = nil) -> Event {
         return Event(name: PlacesConstants.EventName.Request.SET_ACCURACY,
                      type: EventType.places,
                      source: EventSource.requestContent,
-                     data: [
+                     data: data ?? [
                         PlacesConstants.EventDataKey.Places.REQUEST_TYPE: PlacesConstants.EventDataKey.Places.RequestType.SET_ACCURACY,
                         PlacesConstants.EventDataKey.Places.ACCURACY: "full"
                      ])
@@ -340,8 +340,11 @@ class PlacesTests: XCTestCase {
         // setup
         prepareConfig(privacy: .optedIn)
         mockQueryService.returnValue = PlacesQueryServiceResult(pois: [poi, poi2], response: .ok)
-        let requestingEvent = getGetNearbyPlacesRequestEvent()
-        requestingEvent.data?[PlacesConstants.EventDataKey.Places.COUNT] = nil
+        let requestingEvent = getGetNearbyPlacesRequestEvent([
+            PlacesConstants.EventDataKey.Places.LATITUDE: 12.34,
+            PlacesConstants.EventDataKey.Places.LONGITUDE: 23.45,
+            PlacesConstants.EventDataKey.Places.REQUEST_TYPE: PlacesConstants.EventDataKey.Places.RequestType.GET_NEARBY_PLACES
+         ])
         
         // test
         mockRuntime.simulateComingEvents(requestingEvent)
@@ -486,8 +489,11 @@ class PlacesTests: XCTestCase {
     func testHandleGetNearbyPlacesNoLatitudeInEventData() throws {
         // setup
         prepareConfig(privacy: .optedIn)
-        let requestingEvent = getGetNearbyPlacesRequestEvent()
-        requestingEvent.data![PlacesConstants.EventDataKey.Places.LATITUDE] = nil
+        let requestingEvent = getGetNearbyPlacesRequestEvent([
+            PlacesConstants.EventDataKey.Places.LONGITUDE: 23.45,
+            PlacesConstants.EventDataKey.Places.COUNT: 7,
+            PlacesConstants.EventDataKey.Places.REQUEST_TYPE: PlacesConstants.EventDataKey.Places.RequestType.GET_NEARBY_PLACES
+         ])
         
         // test
         mockRuntime.simulateComingEvents(requestingEvent)
@@ -508,8 +514,11 @@ class PlacesTests: XCTestCase {
     func testHandleGetNearbyPlacesNoLongitudeInEventData() throws {
         // setup
         prepareConfig(privacy: .optedIn)
-        let requestingEvent = getGetNearbyPlacesRequestEvent()
-        requestingEvent.data![PlacesConstants.EventDataKey.Places.LONGITUDE] = nil
+        let requestingEvent = getGetNearbyPlacesRequestEvent([
+            PlacesConstants.EventDataKey.Places.LATITUDE: 12.34,
+            PlacesConstants.EventDataKey.Places.COUNT: 7,
+            PlacesConstants.EventDataKey.Places.REQUEST_TYPE: PlacesConstants.EventDataKey.Places.RequestType.GET_NEARBY_PLACES
+         ])
         
         // test
         mockRuntime.simulateComingEvents(requestingEvent)
@@ -676,8 +685,10 @@ class PlacesTests: XCTestCase {
     func testHandleProcessRegionEventRequestMissingRegionId() throws {
         // setup
         prepareConfig(privacy: .optedIn)
-        let requestingEvent = getProcessRegionEvent()
-        requestingEvent.data![PlacesConstants.EventDataKey.Places.REGION_ID] = nil
+        let requestingEvent = getProcessRegionEvent([
+            PlacesConstants.EventDataKey.Places.REGION_EVENT_TYPE: PlacesRegionEvent.entry.stringValue,
+            PlacesConstants.EventDataKey.Places.REQUEST_TYPE: PlacesConstants.EventDataKey.Places.RequestType.PROCESS_REGION_EVENT
+         ])
         
         // test
         mockRuntime.simulateComingEvents(requestingEvent)
@@ -689,8 +700,10 @@ class PlacesTests: XCTestCase {
     func testHandleProcessRegionEventRequestMissingRegionEventType() throws {
         // setup
         prepareConfig(privacy: .optedIn)
-        let requestingEvent = getProcessRegionEvent()
-        requestingEvent.data![PlacesConstants.EventDataKey.Places.REGION_EVENT_TYPE] = nil
+        let requestingEvent = getProcessRegionEvent([
+            PlacesConstants.EventDataKey.Places.REGION_ID: "1234",
+            PlacesConstants.EventDataKey.Places.REQUEST_TYPE: PlacesConstants.EventDataKey.Places.RequestType.PROCESS_REGION_EVENT
+         ])
         
         // test
         mockRuntime.simulateComingEvents(requestingEvent)
@@ -840,8 +853,9 @@ class PlacesTests: XCTestCase {
         
         // setup
         prepareConfig(privacy: .optedIn)
-        let requestingEvent = getSetAccuracyAuthorizationRequestEvent()
-        requestingEvent.data?[PlacesConstants.EventDataKey.Places.ACCURACY] = nil
+        let requestingEvent = getSetAccuracyAuthorizationRequestEvent([
+            PlacesConstants.EventDataKey.Places.REQUEST_TYPE: PlacesConstants.EventDataKey.Places.RequestType.SET_ACCURACY
+        ])
         XCTAssertNil(places.accuracy)
         
         // test
@@ -873,8 +887,9 @@ class PlacesTests: XCTestCase {
     func testSetAuthorizationStatusNoStatusInEventData() throws {
         // setup
         prepareConfig(privacy: .optedIn)
-        let requestingEvent = getSetAuthorizationStatusRequestEvent()
-        requestingEvent.data?[PlacesConstants.EventDataKey.Places.AUTH_STATUS] = nil
+        let requestingEvent = getSetAuthorizationStatusRequestEvent([
+            PlacesConstants.EventDataKey.Places.REQUEST_TYPE: PlacesConstants.EventDataKey.Places.RequestType.SET_AUTHORIZATION_STATUS
+        ])        
         XCTAssertEqual(.notDetermined, places.authStatus)
         
         // test

--- a/AEPPlaces/Tests/PointOfInterestTests.swift
+++ b/AEPPlaces/Tests/PointOfInterestTests.swift
@@ -26,7 +26,11 @@ class PointOfInterestTests: XCTestCase {
         "libraryid": "mylib",
         "useriswithin": false,
         "regionmetadata": {
-            "key1": "value1"
+            "stringKey": "value1",
+            "intKey": 9,
+            "doubleKey": 55.2,
+            "boolKey": true,
+            "nullKey": null
         }
     }
     """
@@ -105,8 +109,12 @@ class PointOfInterestTests: XCTestCase {
         XCTAssertEqual(23.45, poi.longitude)
         XCTAssertEqual(500, poi.radius)
         XCTAssertEqual(false, poi.userIsWithin)
-        XCTAssertEqual(1, poi.metaData.count)
-        XCTAssertEqual("value1", poi.metaData["key1"])
+        XCTAssertEqual(5, poi.metaData.count)
+        XCTAssertEqual("value1", poi.metaData["stringKey"] as? String)
+        XCTAssertEqual(9, poi.metaData["intKey"] as? Int)
+        XCTAssertEqual(55.2, poi.metaData["doubleKey"] as? Double)
+        XCTAssertEqual(true, poi.metaData["boolKey"] as? Bool)
+        XCTAssertEqual(NSNull.init(), poi.metaData["nullKey"] as? NSNull)
     }
     
     func testConstructorFromJsonStringEmptyJson() throws {
@@ -144,7 +152,7 @@ class PointOfInterestTests: XCTestCase {
         XCTAssertEqual(500, poi.radius)
         XCTAssertEqual(false, poi.userIsWithin)
         XCTAssertEqual(1, poi.metaData.count)
-        XCTAssertEqual("value1", poi.metaData["key1"])
+        XCTAssertEqual("value1", poi.metaData["key1"] as? String)
     }
     
     func testConstructorFromJsonObjectHappyUserWithin() throws {
@@ -160,7 +168,7 @@ class PointOfInterestTests: XCTestCase {
         XCTAssertEqual(500, poi.radius)
         XCTAssertEqual(true, poi.userIsWithin)
         XCTAssertEqual(1, poi.metaData.count)
-        XCTAssertEqual("value1", poi.metaData["key1"])
+        XCTAssertEqual("value1", poi.metaData["key1"] as? String)
     }
     
     func testConstructorFromJsonObjectIncorrectJsonArrayData() throws {

--- a/AEPPlaces/Tests/PointOfInterestTests.swift
+++ b/AEPPlaces/Tests/PointOfInterestTests.swift
@@ -110,11 +110,11 @@ class PointOfInterestTests: XCTestCase {
         XCTAssertEqual(500, poi.radius)
         XCTAssertEqual(false, poi.userIsWithin)
         XCTAssertEqual(5, poi.metaData.count)
-        XCTAssertEqual("value1", poi.metaData["stringKey"] as? String)
-        XCTAssertEqual(9, poi.metaData["intKey"] as? Int)
-        XCTAssertEqual(55.2, poi.metaData["doubleKey"] as? Double)
-        XCTAssertEqual(true, poi.metaData["boolKey"] as? Bool)
-        XCTAssertEqual(NSNull.init(), poi.metaData["nullKey"] as? NSNull)
+        XCTAssertEqual("value1", poi.metaData["stringKey"])
+        XCTAssertEqual("9", poi.metaData["intKey"])
+        XCTAssertEqual("55.2", poi.metaData["doubleKey"])
+        XCTAssertEqual("1", poi.metaData["boolKey"])
+        XCTAssertEqual("<null>", poi.metaData["nullKey"])
     }
     
     func testConstructorFromJsonStringEmptyJson() throws {

--- a/AEPPlaces/Tests/Utils/TestableExtensionRuntime.swift
+++ b/AEPPlaces/Tests/Utils/TestableExtensionRuntime.swift
@@ -17,6 +17,18 @@ import Foundation
 ///
 /// Enable easy setup for the input and verification of the output of an extension
 public class TestableExtensionRuntime: ExtensionRuntime {
+    public func getSharedState(extensionName: String, event: AEPCore.Event?, barrier: Bool, resolution: AEPCore.SharedStateResolution) -> AEPCore.SharedStateResult? {
+        return nil
+    }
+    
+    public func getXDMSharedState(extensionName: String, event: AEPCore.Event?, barrier: Bool, resolution: AEPCore.SharedStateResolution) -> AEPCore.SharedStateResult? {
+        return nil
+    }
+    
+    public func getHistoricalEvents(_ requests: [AEPCore.EventHistoryRequest], enforceOrder: Bool, handler: @escaping ([AEPCore.EventHistoryResult]) -> Void) {
+        
+    }
+    
     public var listeners: [String: EventListener] = [:]
     public var dispatchedEvents: [Event] = []
     public var createdSharedStates: [[String: Any]?] = []

--- a/Documentation/USAGE.md
+++ b/Documentation/USAGE.md
@@ -345,7 +345,7 @@ func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
 | latitude | Double |
 | libraryId | String |
 | longitude | Double |
-| metaData | [String: String] |
+| metaData | [String: Any] |
 | name | String |
 | radius | Int |
 | userIsWithin | Bool |

--- a/Documentation/USAGE.md
+++ b/Documentation/USAGE.md
@@ -345,7 +345,7 @@ func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
 | latitude | Double |
 | libraryId | String |
 | longitude | Double |
-| metaData | [String: Any] |
+| metaData | [String: String] |
 | name | String |
 | radius | Int |
 | userIsWithin | Bool |

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ open:
 clean:
 	(rm -rf build)
 
-archive:
+archive: pod-install
 	xcodebuild archive -workspace $(PROJECT_NAME).xcworkspace -scheme $(SCHEME_NAME_XCFRAMEWORK) -archivePath "./build/ios.xcarchive" -sdk iphoneos -destination="iOS" SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
 	xcodebuild archive -workspace $(PROJECT_NAME).xcworkspace -scheme $(SCHEME_NAME_XCFRAMEWORK) -archivePath "./build/ios_simulator.xcarchive" -sdk iphonesimulator -destination="iOS Simulator" SKIP_INSTALL=NO BUILD_LIBRARIES_FOR_DISTRIBUTION=YES
 	xcodebuild -create-xcframework -framework $(SIMULATOR_ARCHIVE_PATH)$(EXTENSION_NAME).framework -framework $(IOS_ARCHIVE_PATH)$(EXTENSION_NAME).framework -output ./build/$(TARGET_NAME_XCFRAMEWORK)

--- a/Makefile
+++ b/Makefile
@@ -43,17 +43,22 @@ test:
 	@echo "######################################################################"
 	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme $(PROJECT_NAME) -destination 'platform=iOS Simulator,name=iPhone 8' -derivedDataPath build/out -enableCodeCoverage YES
 
-install-swiftlint:
-	HOMEBREW_NO_AUTO_UPDATE=1 brew install swiftlint && brew cleanup swiftlint
-
 install-githook:
 	./Scripts/git-hooks/setup.sh
 
+format: swift-format lint-autocorrect
+
+install-swiftformat:
+	(brew install swiftformat)
+
+swift-format:
+	(swiftformat $(PROJECT_NAME)/Sources --swiftversion 5.1)
+
 lint-autocorrect:
-	(swiftlint autocorrect --format)
+	(./Pods/SwiftLint/swiftlint --fix $(PROJECT_NAME)/Sources --format)
 
 lint:
-	(swiftlint lint Sources TestApps/$(APP_NAME))
+	(./Pods/SwiftLint/swiftlint lint $(PROJECT_NAME)/Sources)
 
 build-test-apps:
 	xcodebuild -workspace $(PROJECT_NAME).xcworkspace -scheme $(APP_NAME) -destination 'platform=iOS Simulator,name=iPhone 8'

--- a/Podfile
+++ b/Podfile
@@ -32,8 +32,7 @@ def test_main
     pod 'AEPIdentity'
     pod 'AEPLifecycle'
     pod 'AEPSignal'
-    pod 'AEPAssurance'
-    pod 'ACPCore', :git => 'https://github.com/adobe/aep-sdk-compatibility-ios.git', :branch => 'main'
+    pod 'AEPAssurance'    
 end
 
 # test app against dev branches
@@ -43,8 +42,7 @@ def test_dev
     pod 'AEPIdentity', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.1.2'
     pod 'AEPLifecycle', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.1.2'
     pod 'AEPSignal', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.1.2'
-    pod 'AEPAssurance' #todo - get a link to this repo once it's public
-    pod 'ACPCore', :git => 'https://github.com/adobe/aep-sdk-compatibility-ios.git', :branch => 'main'
+    pod 'AEPAssurance', :git => 'https://github.com/adobe/aepsdk-assurance-ios.git', :branch => 'main'
 end
 
 # ==================

--- a/Podfile
+++ b/Podfile
@@ -10,6 +10,8 @@ install! 'cocoapods', :warn_for_unused_master_specs_repo => false
 workspace 'AEPPlaces'
 project 'AEPPlaces.xcodeproj'
 
+pod 'SwiftLint', '0.44.0'
+
 # ==================
 # SHARED POD GROUPS
 # ==================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -16,6 +16,7 @@ PODS:
   - AEPServices (3.7.1)
   - AEPSignal (3.7.1):
     - AEPCore (>= 3.7.1)
+  - SwiftLint (0.44.0)
 
 DEPENDENCIES:
   - AEPAnalytics
@@ -25,6 +26,7 @@ DEPENDENCIES:
   - AEPLifecycle
   - AEPServices
   - AEPSignal
+  - SwiftLint (= 0.44.0)
 
 SPEC REPOS:
   trunk:
@@ -36,6 +38,7 @@ SPEC REPOS:
     - AEPRulesEngine
     - AEPServices
     - AEPSignal
+    - SwiftLint
 
 SPEC CHECKSUMS:
   AEPAnalytics: b83efee29b4323537cbce4b8f146d26cee6cdc80
@@ -46,7 +49,8 @@ SPEC CHECKSUMS:
   AEPRulesEngine: 71228dfdac24c9ded09be13e3257a7eb22468ccc
   AEPServices: 7284c30359c789cd16bf366b4ea81094a66d21ab
   AEPSignal: c9b3c239120190fae8e8479d584d54b60af37d99
+  SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
 
-PODFILE CHECKSUM: 1c99b45bdde1dd70ff9600d4b7e50ccede0411be
+PODFILE CHECKSUM: 38907f8dc2d73b3e09adf204912bd9aef1e05101
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,33 +1,23 @@
 PODS:
-  - ACPCore (2.9.9):
-    - AEPCore
-    - AEPIdentity
-    - AEPLifecycle
-    - AEPRulesEngine
-    - AEPServices
-    - AEPSignal
-  - AEPAnalytics (3.0.1):
-    - AEPCore
-    - AEPServices
-  - AEPAssurance (1.1.1):
-    - ACPCore (>= 2.9.0)
-    - AEPAssurance/xcframeworks (= 1.1.1)
-  - AEPAssurance/xcframeworks (1.1.1):
-    - ACPCore (>= 2.9.0)
-  - AEPCore (3.1.3):
-    - AEPRulesEngine (= 1.0.1)
-    - AEPServices (= 3.1.3)
-  - AEPIdentity (3.1.3):
-    - AEPCore (= 3.1.3)
-  - AEPLifecycle (3.1.3):
-    - AEPCore (= 3.1.3)
-  - AEPRulesEngine (1.0.1)
-  - AEPServices (3.1.3)
-  - AEPSignal (3.1.3):
-    - AEPCore (= 3.1.3)
+  - AEPAnalytics (3.2.0):
+    - AEPCore (>= 3.7.0)
+    - AEPServices (>= 3.7.0)
+  - AEPAssurance (3.0.1):
+    - AEPCore (>= 3.1.0)
+    - AEPServices (>= 3.1.0)
+  - AEPCore (3.7.1):
+    - AEPRulesEngine (>= 1.1.0)
+    - AEPServices (>= 3.7.1)
+  - AEPIdentity (3.7.1):
+    - AEPCore (>= 3.7.1)
+  - AEPLifecycle (3.7.1):
+    - AEPCore (>= 3.7.1)
+  - AEPRulesEngine (1.2.0)
+  - AEPServices (3.7.1)
+  - AEPSignal (3.7.1):
+    - AEPCore (>= 3.7.1)
 
 DEPENDENCIES:
-  - ACPCore (from `https://github.com/adobe/aep-sdk-compatibility-ios.git`, branch `main`)
   - AEPAnalytics
   - AEPAssurance
   - AEPCore
@@ -47,27 +37,16 @@ SPEC REPOS:
     - AEPServices
     - AEPSignal
 
-EXTERNAL SOURCES:
-  ACPCore:
-    :branch: main
-    :git: https://github.com/adobe/aep-sdk-compatibility-ios.git
-
-CHECKOUT OPTIONS:
-  ACPCore:
-    :commit: c43675de0c97ee76fd51b005e8c9cdc7515e4a78
-    :git: https://github.com/adobe/aep-sdk-compatibility-ios.git
-
 SPEC CHECKSUMS:
-  ACPCore: 67e4b855bf16cfb6a63024a4ddb73d15c0fd30e5
-  AEPAnalytics: 13353b3ea333be0af7cfc4845830d87d360726e2
-  AEPAssurance: b62fc1be16efbc8d137b945b29da7e5ec7c7965a
-  AEPCore: 6ec14ec9b1ff45999ea53be112aba85522ad00c4
-  AEPIdentity: 49e6c742238be0f77d5ae8928c13acfd1d8bec3c
-  AEPLifecycle: 9ed7ceabd98cc5c94b13c3b085c9f1eef2c714fe
-  AEPRulesEngine: 5075ed294026a12e37bd26fe260f74604d205354
-  AEPServices: e032bfacfcb31f3a583b2aa1e87df5d427cca95d
-  AEPSignal: c0619814fbf50dbb1dde4e79141d528aa2606e9e
+  AEPAnalytics: b83efee29b4323537cbce4b8f146d26cee6cdc80
+  AEPAssurance: b25880cd4b14f22c61a1dce19807bd0ca0fe9b17
+  AEPCore: 412fe933382892ab6c6af958d2f69ebcbca11216
+  AEPIdentity: 7cd5a51d8012aeaeee769e99597db016ad68b0d1
+  AEPLifecycle: 94c36a54f7e5466c5274bc822c53eaa410b74888
+  AEPRulesEngine: 71228dfdac24c9ded09be13e3257a7eb22468ccc
+  AEPServices: 7284c30359c789cd16bf366b4ea81094a66d21ab
+  AEPSignal: c9b3c239120190fae8e8479d584d54b60af37d99
 
-PODFILE CHECKSUM: 3f8f5ccbed2a1029da9c77bcf40db2a3a8a72cf5
+PODFILE CHECKSUM: 1c99b45bdde1dd70ff9600d4b7e50ccede0411be
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.3

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To generate `AEPPlaces.xcframework`, run the following command from the root dir
 make archive
 ```
 
-This will generate an XCFramework under the `build` folder. Drag and drop `AEPPlaces.xcframework` to your app target.
+This will do a `pod install` then generate an XCFramework under the `build` folder. Drag and drop `AEPPlaces.xcframework` to your app target.
 
 ### [CocoaPods](https://guides.cocoapods.org/using/using-cocoapods.html)
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,15 @@ end
 
 ### [Swift Package Manager](https://github.com/apple/swift-package-manager)
 
-To add the AEPPlaces Package to your application, from the Xcode menu select:
+To add the AEPPlaces package to your application, from the Xcode menu select:
 
-`File > Swift Packages > Add Package Dependency...`
+`File > Add Packages...`
+
+> **Note**: the menu options may vary depending on the version of Xcode being used.
 
 Enter the URL for the AEPPlaces package repository: `https://github.com/adobe/aepsdk-places-ios.git`.
+
+For `Dependency Rule`, select `Up to Next Major Version`.
 
 Alternatively, if your project has a `Package.swift` file, you can add AEPPlaces directly to your dependencies:
 

--- a/TestApps/PlacesTestApp/AppDelegate.swift
+++ b/TestApps/PlacesTestApp/AppDelegate.swift
@@ -29,9 +29,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         MobileCore.configureWith(appId: "launch-EN459260fc579a4dcbb2d1743947e65f09-development")
         
         let appState = application.applicationState
-        MobileCore.registerExtensions([Places.self, Signal.self, Analytics.self, Identity.self, Lifecycle.self, AEPAssurance.self]) {
+        MobileCore.registerExtensions([Places.self, Signal.self, Analytics.self, Identity.self, Lifecycle.self, Assurance.self]) {
             // Griffon Session - AEPPlaces in Adobe Benedick Corp
-            AEPAssurance.startSession(URL(string: "aepplaces://?adb_validation_sessionid=ecc9abb0-9028-4312-bc1d-a16920353e79")!)
+            Assurance.startSession(url: URL(string: "aepplaces://?adb_validation_sessionid=ecc9abb0-9028-4312-bc1d-a16920353e79")!)
             
             if appState != .background {
                 MobileCore.lifecycleStart(additionalContextData: nil)

--- a/TestApps/PlacesTestApp_objc/AppDelegate.m
+++ b/TestApps/PlacesTestApp_objc/AppDelegate.m
@@ -13,7 +13,6 @@
 #import "AppDelegate.h"
 @import AEPCore;
 @import AEPPlaces;
-@import ACPCore;
 @import AEPAssurance;
 @import AEPServices;
 
@@ -26,9 +25,9 @@
     // steve-places in Adobe Benedick Corp: launch-EN459260fc579a4dcbb2d1743947e65f09-development
     [AEPMobileCore configureWithAppId:@"launch-EN459260fc579a4dcbb2d1743947e65f09-development"];
     
-    [AEPMobileCore registerExtensions:@[AEPMobilePlaces.class, AEPAssurance.class] completion:^{
+    [AEPMobileCore registerExtensions:@[AEPMobilePlaces.class, AEPMobileAssurance.class] completion:^{
         // Griffon Session - AEPPlaces_objc in Adobe Benedick Corp
-        [AEPAssurance startSession:[NSURL URLWithString:@"aepplaces://?adb_validation_sessionid=45028228-fc99-4865-87cb-99351de0c064"]];
+        [AEPMobileAssurance startSessionWithUrl:[NSURL URLWithString:@"aepplaces://?adb_validation_sessionid=45028228-fc99-4865-87cb-99351de0c064"]];
         NSLog(@"places version: %@", [AEPMobilePlaces extensionVersion]);
     }];
         


### PR DESCRIPTION
## Description

- fixes a bug that was causing POI metadata containing non-string values to always be empty
  - Places extension will now force convert all values in metadata to `String` using `String(describing:)`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
