### PR TITLE
To Main - Feature: Send Location Entry/Exit events to platform

### DIFF
--- a/.github/workflows/update_versions.yml
+++ b/.github/workflows/update_versions.yml
@@ -9,7 +9,7 @@ on:
     # Inputs the workflow accepts.
     inputs:
       version:
-        description: 'New version to use for the Places extension.  Example: 3.0.2'
+        description: 'New version to use for the Places extension.  Example: 4.0.0'
         required: true
         
       branch:

--- a/AEPPlaces.podspec
+++ b/AEPPlaces.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "AEPPlaces"
-  s.version      = "4.0.0"
+  s.version      = "4.1.0"
   s.summary      = "Places extension for Adobe Experience Cloud SDK. Written and maintained by Adobe."
   s.description  = <<-DESC
                    The Places extension is used in conjunction with Adobe Experience Platform to deliver location functionality.

--- a/AEPPlaces.xcodeproj/project.pbxproj
+++ b/AEPPlaces.xcodeproj/project.pbxproj
@@ -1053,7 +1053,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.0;
+				MARKETING_VERSION = 4.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.places;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -1084,7 +1084,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.0;
+				MARKETING_VERSION = 4.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.places;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/AEPPlaces.xcodeproj/project.pbxproj
+++ b/AEPPlaces.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		079EEFA52841818C00FD67F2 /* Places+EdgeEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079EEFA42841818B00FD67F2 /* Places+EdgeEvents.swift */; };
 		09F3D002F490B5D55CCF0DA7 /* Pods_AEPPlaces.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B564B4991C7921C27904C90 /* Pods_AEPPlaces.framework */; };
 		2407DF50264C9396002B070F /* MockDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2407DF4E264C9396002B070F /* MockDataStore.swift */; };
 		2407DF51264C9396002B070F /* MockNetworkServiceOverrider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2407DF4F264C9396002B070F /* MockNetworkServiceOverrider.swift */; };
@@ -123,6 +124,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		079EEFA42841818B00FD67F2 /* Places+EdgeEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Places+EdgeEvents.swift"; sourceTree = "<group>"; };
 		0B564B4991C7921C27904C90 /* Pods_AEPPlaces.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPPlaces.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0DF0DA3F1EFC247D845A0CD6 /* Pods-PlacesTestApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PlacesTestApp.release.xcconfig"; path = "Target Support Files/Pods-PlacesTestApp/Pods-PlacesTestApp.release.xcconfig"; sourceTree = "<group>"; };
 		2407DF4E264C9396002B070F /* MockDataStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDataStore.swift; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 				243AC708262A4345006501EC /* PlacesRegionEvent.swift */,
 				243AC6F0262A42FB006501EC /* PointOfInterest.swift */,
 				243AC7AB263885CC006501EC /* SharedStateResult+Places.swift */,
+				079EEFA42841818B00FD67F2 /* Places+EdgeEvents.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -762,6 +765,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				079EEFA52841818C00FD67F2 /* Places+EdgeEvents.swift in Sources */,
 				24F2AED9265EACDE007C632F /* CLAccuracyAuthorization+Places.swift in Sources */,
 				243AC6F9262A4316006501EC /* Places+PublicApi.swift in Sources */,
 				243AC6E9262A41C0006501EC /* PlacesConfiguration.swift in Sources */,

--- a/AEPPlaces/Sources/Places+EdgeEvents.swift
+++ b/AEPPlaces/Sources/Places+EdgeEvents.swift
@@ -1,0 +1,97 @@
+/*
+ Copyright 2023 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import AEPCore
+import AEPServices
+import Foundation
+
+extension Places {
+
+    /// Sends an experience event to the edge server for the specified geofence entry/exit location event.
+    ///
+    /// - Parameters:
+    ///   - event: The region event representing geofence entry/exit.
+    ///   - poi: The PointOfInterest object associated with the event.
+    ///   - type: The PlacesRegionEvent representing the region event type (entry or exit).
+    func sendExperienceEventToEdge(event: Event, poi: PointOfInterest, withRegionEventType type: PlacesRegionEvent) {
+
+        // add eventType and prescribed data for the experience info
+        let poiInteraction: [String: Any] = [
+            PlacesConstants.XDM.Key.POI_DETAIL: createXDMPOIDetail(poi: poi)
+        ]
+
+        let xdmMap: [String: Any] = [
+            PlacesConstants.XDM.Key.EVENT_TYPE: type.experienceEventType,
+            PlacesConstants.XDM.Key.PLACE_CONTEXT: [
+                PlacesConstants.XDM.Key.POI_INTERACTION: poiInteraction
+            ]
+        ]
+
+        // Creating xdm edge event data
+        let xdmEventData: [String: Any] = [
+            PlacesConstants.XDM.Key.XDM: xdmMap
+        ]
+
+        // create the mask for storing event history
+        let mask = [
+            PlacesConstants.EventMask.EVENT_TYPE,
+            PlacesConstants.EventMask.POIID
+        ]
+
+        // Creating xdm edge event with request content source type
+        let event = Event(name: PlacesConstants.EventName.Request.LOCATION_TRACKING,
+                          type: EventType.edge,
+                          source: EventSource.requestContent,
+                          data: xdmEventData,
+                          mask: mask)
+        dispatch(event: event)
+    }
+
+    /// Creates an XDM (Experience Data Model) representation of a Point of Interest (POI) detail based on the provided POI object.
+    ///
+    /// - Parameter poi: The PointOfInterest object for which the XDM POI detail needs to be created.
+    /// - Returns: A dictionary containing the XDM representation of the POI detail, following the XDM specification.
+    private func createXDMPOIDetail(poi: PointOfInterest) -> [String: Any] {
+        // Create a dictionary representing the XDM POI detail
+        let poiDetail: [String: Any] = [
+            PlacesConstants.XDM.Key.POI_ID: poi.identifier,
+            PlacesConstants.XDM.Key.POI_NAME: poi.name,
+            PlacesConstants.XDM.Key.POI_METADATA: createPOIMetadata(poi: poi)
+        ]
+        
+        // Return the XDM POI detail dictionary
+        return poiDetail
+    }
+
+    /// Creates metadata for a Point of Interest (POI) based on the provided POI object.
+    ///
+    /// - Parameter poi: The PointOfInterest object for which the metadata needs to be created.
+    /// - Returns: A dictionary containing the metadata for the POI, with keys and values following the XDM specification.
+    private func createPOIMetadata(poi: PointOfInterest) -> [String: Any] {
+        var list = [[String: Any]]()
+
+        // Iterate over the metadata key-value pairs of the POI
+        for (metaKey, metaValue) in poi.metaData {
+            // Create a dictionary representing a metadata tuple
+            let metaTuple: [String: Any] = [
+                PlacesConstants.XDM.Key.KEY: metaKey,
+                PlacesConstants.XDM.Key.VALUE: metaValue
+            ]
+
+            list.append(metaTuple)
+        }
+
+        let metadata: [String: Any] = [PlacesConstants.XDM.Key.LIST: list]
+        return metadata
+    }
+
+}

--- a/AEPPlaces/Sources/Places.swift
+++ b/AEPPlaces/Sources/Places.swift
@@ -256,6 +256,8 @@ public class Places: NSObject, Extension {
         processRegionEvent(regionEventType, forPoi: triggeringPoi)
 
         dispatchRegionEventFor(poi: triggeringPoi, withRegionEventType: regionEventType)
+
+        sendExperienceEventToEdge(event: event, poi: triggeringPoi, withRegionEventType: regionEventType)
     }
 
     private func getPlacesConfiguration(forEvent event: Event) -> PlacesConfiguration? {

--- a/AEPPlaces/Sources/PlacesConstants.swift
+++ b/AEPPlaces/Sources/PlacesConstants.swift
@@ -14,7 +14,7 @@ import Foundation
 
 enum PlacesConstants {
     static let EXTENSION_NAME = "com.adobe.module.places"
-    static let EXTENSION_VERSION = "4.0.0"
+    static let EXTENSION_VERSION = "4.1.0"
     static let FRIENDLY_NAME = "Places"
     static let LOG_TAG = "Places"
 

--- a/AEPPlaces/Sources/PlacesConstants.swift
+++ b/AEPPlaces/Sources/PlacesConstants.swift
@@ -21,7 +21,7 @@ enum PlacesConstants {
     enum DefaultValues {
         static let MEMBERSHIP_TTL: TimeInterval = 60 * 60 // 1 hour in seconds
         static let NEARBY_POI_COUNT = 10
-        static let RADIUS = 1_000 // 1 km
+        static let RADIUS = 1000 // 1 km
         static let INVALID_LAT_LON = 999.999
     }
 
@@ -88,6 +88,7 @@ enum PlacesConstants {
             static let RESET = "requestreset"
             static let SET_ACCURACY = "requestsetaccuracy"
             static let SET_AUTHORIZATION_STATUS = "requestsetauthorizationstatus"
+            static let LOCATION_TRACKING = "Location Tracking Event"
         }
 
         enum Response {
@@ -145,5 +146,33 @@ enum PlacesConstants {
                 static let SET_AUTHORIZATION_STATUS = "requestsetauthorizationstatus"
             }
         }
+    }
+
+    enum XDM {
+        enum Key {
+            static let EVENT_TYPE = "eventType"
+            static let XDM = "xdm"
+            static let PLACE_CONTEXT = "placeContext"
+            static let POI_INTERACTION = "POIinteraction"
+            static let POI_DETAIL = "poiDetail"
+            static let POI_ID = "poiID"
+            static let POI_NAME = "name"
+            static let POI_METADATA = "metadata"
+            static let LIST = "list"
+            static let KEY = "key"
+            static let VALUE = "value"
+        }
+
+        enum Location {
+            enum EventType {
+                static let ENTRY = "location.entry"
+                static let EXIT = "location.exit"
+            }
+        }
+    }
+    
+    enum EventMask {
+        static let EVENT_TYPE = "xdm.eventType"
+        static let POIID = "xdm.placeContext.POIinteraction.poiDetail.poiID"
     }
 }

--- a/AEPPlaces/Sources/PlacesRegionEvent.swift
+++ b/AEPPlaces/Sources/PlacesRegionEvent.swift
@@ -28,7 +28,17 @@ public enum PlacesRegionEvent: Int {
             return "exit"
         }
     }
+    
+    var experienceEventType : String {
+        switch self {
+        case .entry:
+            return PlacesConstants.XDM.Location.EventType.ENTRY
 
+        case .exit:
+            return PlacesConstants.XDM.Location.EventType.EXIT
+        }
+    }
+    
     /// Converts a `String` to its respective `PlacesRegionEvent`
     /// If `string` is not a valid `PlacesRegionEvent`, calling this method will return `nil`
     /// - Parameter string: a `String` representation of a `PlacesRegionEvent`

--- a/AEPPlaces/Sources/SharedStateResult+Places.swift
+++ b/AEPPlaces/Sources/SharedStateResult+Places.swift
@@ -32,4 +32,5 @@ extension SharedStateResult {
     var globalPrivacy: PrivacyStatus {
         PrivacyStatus(rawValue: value?[PlacesConstants.EventDataKey.Configuration.GLOBAL_CONFIG_PRIVACY] as? String ?? "unknown")!
     }
+
 }

--- a/AEPPlaces/Tests/PlacesRegionEventTests.swift
+++ b/AEPPlaces/Tests/PlacesRegionEventTests.swift
@@ -70,4 +70,28 @@ class PlacesRegionEventTests: XCTestCase {
         XCTAssertEqual("entry", PlacesRegionEvent.entry.stringValue)
         XCTAssertEqual("exit", PlacesRegionEvent.exit.stringValue)
     }
+    
+    func testToExperienceEventTypeEntry() throws {
+        // setup
+        let entryEvent = PlacesRegionEvent(rawValue: 0)
+        
+        // verify
+        XCTAssertEqual(PlacesConstants.XDM.Location.EventType.ENTRY, entryEvent?.experienceEventType)
+    }
+    
+    func testToExperienceEventTypeExit() throws {
+        // setup
+        let entryEvent = PlacesRegionEvent(rawValue: 1)
+        
+        // verify
+        XCTAssertEqual(PlacesConstants.XDM.Location.EventType.EXIT, entryEvent?.experienceEventType)
+    }
+    
+    func testToExperienceEventTypeInvalid() throws {
+        // setup
+        let entryEvent = PlacesRegionEvent(rawValue: 552)
+        
+        // verify
+        XCTAssertNil(entryEvent?.experienceEventType)
+    }
 }

--- a/AEPPlaces/Tests/PointOfInterestTests.swift
+++ b/AEPPlaces/Tests/PointOfInterestTests.swift
@@ -110,11 +110,11 @@ class PointOfInterestTests: XCTestCase {
         XCTAssertEqual(500, poi.radius)
         XCTAssertEqual(false, poi.userIsWithin)
         XCTAssertEqual(5, poi.metaData.count)
-        XCTAssertEqual("value1", poi.metaData["stringKey"])
-        XCTAssertEqual("9", poi.metaData["intKey"])
-        XCTAssertEqual("55.2", poi.metaData["doubleKey"])
-        XCTAssertEqual("1", poi.metaData["boolKey"])
-        XCTAssertEqual("<null>", poi.metaData["nullKey"])
+        XCTAssertEqual("value1", poi.metaData["stringKey"] as! String?)
+        XCTAssertEqual("9", poi.metaData["intKey"] as! String?)
+        XCTAssertEqual("55.2", poi.metaData["doubleKey"] as! String?)
+        XCTAssertEqual("1", poi.metaData["boolKey"] as! String?)
+        XCTAssertEqual("<null>", poi.metaData["nullKey"] as! String?)
     }
     
     func testConstructorFromJsonStringEmptyJson() throws {

--- a/AEPPlaces/Tests/SharedStateResult+PlacesTests.swift
+++ b/AEPPlaces/Tests/SharedStateResult+PlacesTests.swift
@@ -20,7 +20,8 @@ class SharedStateResultPlusPlacesTests: XCTestCase {
                               placesEndpoint: String? = "test.places.edge",
                               placesMembershipTtl: TimeInterval? = 552,
                               privacy: String? = "optedin",
-                              badPrivacy: Int? = 0) -> SharedStateResult {
+                              badPrivacy: Int? = 0,
+                              datasetId: String? = "1234") -> SharedStateResult {
         var dataMap: [String: Any] = [:]
         
         if placesLibraries != nil {
@@ -116,5 +117,6 @@ class SharedStateResultPlusPlacesTests: XCTestCase {
         
         // verify
         XCTAssertEqual(.unknown, state.globalPrivacy)
-    }    
+    }
+    
 }

--- a/Podfile
+++ b/Podfile
@@ -34,7 +34,10 @@ def test_main
     pod 'AEPIdentity'
     pod 'AEPLifecycle'
     pod 'AEPSignal'
-    pod 'AEPAssurance'    
+    pod 'AEPAssurance'
+    pod 'AEPEdgeIdentity'
+    pod 'AEPEdgeConsent'
+    pod 'AEPEdge'
 end
 
 # test app against dev branches

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,21 @@
 PODS:
-  - AEPAnalytics (3.2.0):
-    - AEPCore (>= 3.7.0)
-    - AEPServices (>= 3.7.0)
+  - AEPAnalytics (4.0.0):
+    - AEPCore (>= 4.0.0)
+    - AEPServices (>= 4.0.0)
   - AEPAssurance (4.0.0):
     - AEPCore (>= 4.0.0)
     - AEPServices (>= 4.0.0)
   - AEPCore (4.0.0):
     - AEPRulesEngine (>= 4.0.0)
     - AEPServices (>= 4.0.0)
+  - AEPEdge (4.0.0):
+    - AEPCore (>= 4.0.0)
+    - AEPEdgeIdentity (>= 4.0.0)
+  - AEPEdgeConsent (4.0.0):
+    - AEPCore (>= 4.0.0)
+    - AEPEdge (>= 4.0.0)
+  - AEPEdgeIdentity (4.0.0):
+    - AEPCore (>= 4.0.0)
   - AEPIdentity (4.0.0):
     - AEPCore (>= 4.0.0)
   - AEPLifecycle (4.0.0):
@@ -22,6 +30,9 @@ DEPENDENCIES:
   - AEPAnalytics
   - AEPAssurance
   - AEPCore
+  - AEPEdge
+  - AEPEdgeConsent
+  - AEPEdgeIdentity
   - AEPIdentity
   - AEPLifecycle
   - AEPServices
@@ -33,6 +44,9 @@ SPEC REPOS:
     - AEPAnalytics
     - AEPAssurance
     - AEPCore
+    - AEPEdge
+    - AEPEdgeConsent
+    - AEPEdgeIdentity
     - AEPIdentity
     - AEPLifecycle
     - AEPRulesEngine
@@ -41,9 +55,12 @@ SPEC REPOS:
     - SwiftLint
 
 SPEC CHECKSUMS:
-  AEPAnalytics: b83efee29b4323537cbce4b8f146d26cee6cdc80
+  AEPAnalytics: a510eb9653fac7f913965ad4291c8d51f74ffdcd
   AEPAssurance: 4fa3138ddd7308c1f9923570f4d2b0b8526a916f
   AEPCore: dd7cd69696c768c610e6adc0307032985a381c7e
+  AEPEdge: ffea1ada1e81c9cb239aac694efa5c8635b50c1f
+  AEPEdgeConsent: 54c1b6a30a3d646e3d4bc4bae1713755422b471e
+  AEPEdgeIdentity: c2396b9119abd6eb530ea11efc58ec019b163bd4
   AEPIdentity: 45ee1c3717e08ff3ca60930caf4a869d60d7bf08
   AEPLifecycle: 59be1b5381d8ec4939ece43516ea7d2de4aaba65
   AEPRulesEngine: 458450a34922823286ead045a0c2bd8c27e224c6
@@ -51,6 +68,6 @@ SPEC CHECKSUMS:
   AEPSignal: b2b332adf4d8a9af6a1b57f5dd8c2e1ea6d5c112
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: dedb90087c2cc1aa684bfc4832ec4452bd2578ba
+PODFILE CHECKSUM: 0f4d132aa02961bca9442bcb74cc3e47aa78fc31
 
 COCOAPODS: 1.11.3

--- a/TestApps/PlacesTestApp/AppDelegate.swift
+++ b/TestApps/PlacesTestApp/AppDelegate.swift
@@ -18,6 +18,9 @@ import AEPSignal
 import AEPAnalytics
 import AEPIdentity
 import AEPLifecycle
+import AEPEdgeIdentity
+import AEPEdge
+import AEPEdgeConsent
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -26,13 +29,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         MobileCore.setLogLevel(.trace)
 
         // steve-places in Adobe Benedick Corp: launch-EN459260fc579a4dcbb2d1743947e65f09-development
-        MobileCore.configureWith(appId: "launch-EN459260fc579a4dcbb2d1743947e65f09-development")
-
+        MobileCore.configureWith(appId: "")
+        
         let appState = application.applicationState
-        MobileCore.registerExtensions([Places.self, Signal.self, Analytics.self, Identity.self, Lifecycle.self, Assurance.self]) {
+        MobileCore.registerExtensions([Places.self, Signal.self, Analytics.self, Identity.self, Lifecycle.self, Assurance.self,  AEPEdgeIdentity.Identity.self, Edge.self, Consent.self]) {
             // Griffon Session - AEPPlaces in Adobe Benedick Corp
-            Assurance.startSession(url: URL(string: "aepplaces://?adb_validation_sessionid=a738aeff-f12d-4015-b4af-bc61969618ce")!)
-
+            Assurance.startSession(url: URL(string: "<YOUR_SESSION_ID>"))        
             if appState != .background {
                 MobileCore.lifecycleStart(additionalContextData: nil)
             }

--- a/TestApps/PlacesTestApp/Base.lproj/Main.storyboard
+++ b/TestApps/PlacesTestApp/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/TestApps/PlacesTestApp_objc/AppDelegate.m
+++ b/TestApps/PlacesTestApp_objc/AppDelegate.m
@@ -15,6 +15,9 @@
 @import AEPPlaces;
 @import AEPAssurance;
 @import AEPServices;
+@import AEPEdge;
+@import AEPEdgeConsent;
+@import AEPEdgeIdentity;
 
 @implementation AppDelegate
 
@@ -25,7 +28,7 @@
     // steve-places in Adobe Benedick Corp: launch-EN459260fc579a4dcbb2d1743947e65f09-development
     [AEPMobileCore configureWithAppId:@"launch-EN459260fc579a4dcbb2d1743947e65f09-development"];
     
-    [AEPMobileCore registerExtensions:@[AEPMobilePlaces.class, AEPMobileAssurance.class] completion:^{
+    [AEPMobileCore registerExtensions:@[AEPMobilePlaces.class, AEPMobileAssurance.class, AEPMobileEdgeConsent.class, AEPMobileEdge.class, AEPMobileEdgeIdentity.class] completion:^{
         // Griffon Session - AEPPlaces_objc in Adobe Benedick Corp
         [AEPMobileAssurance startSessionWithUrl:[NSURL URLWithString:@"aepplaces://?adb_validation_sessionid=45028228-fc99-4865-87cb-99351de0c064"]];
         NSLog(@"places version: %@", [AEPMobilePlaces extensionVersion]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added logic to dispatch Edge Request Content Event every time a location entry or exit occurs. Places data are sent to the default Edge dataset configured in the applications datastream. The XDM field group used to populate the Places data is the EnvironmentDetails->PlacesContext. PoiId, PoiName and POIMetadata are the fields sent from the Places SDK 

<img width="536" alt="Screenshot 2023-06-20 at 9 31 33 AM" src="https://github.com/adobe/aepsdk-places-ios/assets/8909148/8511cafc-1ff6-48c0-b00b-25aeaf47a8b3">

## Motivation and Context

The motivation behind this change is to be able to use the newly added experience events as triggers for AJO Campaigns and Journeys.

## How Has This Been Tested?

Added unit and integration tests to cover the changes. Also tested E2E with AJO Campaigns and Journeys to ensure the triggers are working as expected.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
